### PR TITLE
fix: add input param

### DIFF
--- a/apps/wordsalad/src/config.ts
+++ b/apps/wordsalad/src/config.ts
@@ -11,7 +11,9 @@ const env = envsafe(
       devDefault: 'http://localhost:3000',
       input: import.meta.env.VITE_API_URL,
     }),
-    RENDER_API_KEY: str(),
+    RENDER_API_KEY: str({
+      input: import.meta.env.RENDER_API_KEY,
+    }),
   },
   {
     env: import.meta.env,


### PR DESCRIPTION
quick fix to make the env var available in vite