### PR TITLE
fix(client): send auth header with bearer token

### DIFF
--- a/apps/wordsalad/src/app/GameBoard/index.tsx
+++ b/apps/wordsalad/src/app/GameBoard/index.tsx
@@ -120,7 +120,7 @@ const spellCheckWord = async (wordArray: string[]): Promise<boolean> => {
     method: 'POST',
     url: URL,
     headers: {
-      authorization: `Bearar ${config.renderApiKey}`,
+      authorization: `Bearer ${config.renderApiKey}`,
     },
     data: {
       submittedWord,

--- a/apps/wordsalad/src/app/app.tsx
+++ b/apps/wordsalad/src/app/app.tsx
@@ -40,7 +40,7 @@ const fetchDailySalad = async () => {
     method: 'get',
     url: config.apiUrl,
     headers: {
-      authorization: `Bearar ${config.renderApiKey}`,
+      authorization: `Bearer ${config.renderApiKey}`,
     },
   }).then((result) => {
     const { salad } = result.data;


### PR DESCRIPTION
Quick fix to spelling of `bearer` 