### PR TITLE
fix(api): allow 20.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-client": "nx run wordsalad:build"
   },
   "engines": {
-    "node": "^16.14.0 || ^20.10.0"
+    "node": "^16.14.0 || ^20.9.0"
   },
   "dependencies": {
     "@react-spring/web": "^9.7.3",


### PR DESCRIPTION
Allows use of `20.9.0` for deploy on railway