### PR TITLE
feat: add email link to header

### DIFF
--- a/apps/wordsalad/src/app/header.tsx
+++ b/apps/wordsalad/src/app/header.tsx
@@ -80,7 +80,14 @@ const Header: React.FC = () => (
         '@bp2': 'medium',
       }}
     >
-      by hhk
+      <a
+        href="mailto:henryk1229@gmail.com"
+        target="_blank"
+        rel="noreferrer"
+        style={{ color: 'black', textDecoration: 'none' }}
+      >
+        by hhk
+      </a>
     </Chip>
   </HeaderContainer>
 );


### PR DESCRIPTION
Quick pr to add an email link to the `hhk` in the header