### PR TITLE
feat(client): add share button

### DIFF
--- a/apps/wordsalad/src/app/GameBoard/index.tsx
+++ b/apps/wordsalad/src/app/GameBoard/index.tsx
@@ -139,6 +139,7 @@ interface Props {
   restartGame: () => void;
   setHTPModalOpen: (bool: boolean) => void;
   displayToast: () => void;
+  handleShareResults: () => Promise<void>;
 }
 
 const GameBoard: React.FC<Props> = ({
@@ -153,6 +154,7 @@ const GameBoard: React.FC<Props> = ({
   restartGame,
   setHTPModalOpen,
   displayToast,
+  handleShareResults,
 }) => {
   // control display of stats modal
   const [statsModalOpen, setStatsModalOpen] = useState<boolean>(false);
@@ -333,6 +335,7 @@ const GameBoard: React.FC<Props> = ({
           setRankingsModalOpen={setRankingsModalOpen}
           setStatsModalOpen={setStatsModalOpen}
           setHTPModalOpen={setHTPModalOpen}
+          handleShareResults={handleShareResults}
         />
       </StatsDisplayContainer>
       <BoardWrapper

--- a/apps/wordsalad/src/app/GameLayer.tsx
+++ b/apps/wordsalad/src/app/GameLayer.tsx
@@ -247,7 +247,8 @@ const GameLayer: React.FC<Props> = ({ dailySalad, setHTPModalOpen }) => {
       })
       .join('');
     const numAttempts = isWordSalad ? allAttempts.length : 'X';
-    const text = `WordSalad ${saladNumber} ${numAttempts}/7\n${emojiString}`;
+    const ranking = getRanking({ numAttempts: allAttempts.length });
+    const text = `WordSalad ${saladNumber} ${numAttempts}/7 - ${ranking}\n${emojiString}`;
     try {
       await navigator.clipboard.writeText(text);
       toast(

--- a/apps/wordsalad/src/app/GameLayer.tsx
+++ b/apps/wordsalad/src/app/GameLayer.tsx
@@ -4,6 +4,9 @@ import { DailySalad } from './app';
 import { makeSolutionSets } from './utils';
 import toast, { Toaster } from 'react-hot-toast';
 
+const SALAD_EMOJI = '🥗';
+const TOMATO_EMOJI = '🍅';
+
 export type UserStats = {
   played: number;
   gamesWon: number;
@@ -232,6 +235,39 @@ const GameLayer: React.FC<Props> = ({ dailySalad, setHTPModalOpen }) => {
     );
   };
 
+  const handleShareResults = async () => {
+    let emojiString = '';
+    allAttempts.forEach((att, idx) =>
+      idx === allAttempts.length - 1
+        ? (emojiString += SALAD_EMOJI)
+        : (emojiString += TOMATO_EMOJI)
+    );
+    const text = `WordSalad ${saladNumber} ${allAttempts.length}/7\n\n${emojiString}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      toast(
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <div style={{ margin: '8px' }}>Results copied to clipboard</div>
+        </div>,
+        {
+          id: 'copyResults',
+        }
+      );
+    } catch (error) {
+      const message =
+        error && typeof error === 'object' && 'message' in error
+          ? error.message
+          : null;
+      console.error(message);
+    }
+  };
+
   return (
     <>
       <GameBoard
@@ -247,6 +283,7 @@ const GameLayer: React.FC<Props> = ({ dailySalad, setHTPModalOpen }) => {
         restartGame={restartGame}
         setHTPModalOpen={setHTPModalOpen}
         displayToast={displayToast}
+        handleShareResults={handleShareResults}
       />
       <Toaster
         containerStyle={{ top: '120px' }}

--- a/apps/wordsalad/src/app/GameLayer.tsx
+++ b/apps/wordsalad/src/app/GameLayer.tsx
@@ -247,8 +247,10 @@ const GameLayer: React.FC<Props> = ({ dailySalad, setHTPModalOpen }) => {
       })
       .join('');
     const numAttempts = isWordSalad ? allAttempts.length : 'X';
-    const ranking = getRanking({ numAttempts: allAttempts.length });
-    const text = `WordSalad ${saladNumber} ${numAttempts}/7 - ${ranking}\n${emojiString}`;
+    const rankingText = isWordSalad
+      ? ` - ${getRanking({ numAttempts: allAttempts.length })}`
+      : '';
+    const text = `WordSalad ${saladNumber} ${numAttempts}/7${rankingText}\n${emojiString}`;
     try {
       await navigator.clipboard.writeText(text);
       toast(

--- a/apps/wordsalad/src/app/GameLayer.tsx
+++ b/apps/wordsalad/src/app/GameLayer.tsx
@@ -236,13 +236,18 @@ const GameLayer: React.FC<Props> = ({ dailySalad, setHTPModalOpen }) => {
   };
 
   const handleShareResults = async () => {
-    let emojiString = '';
-    allAttempts.forEach((att, idx) =>
-      idx === allAttempts.length - 1
-        ? (emojiString += SALAD_EMOJI)
-        : (emojiString += TOMATO_EMOJI)
-    );
-    const text = `WordSalad ${saladNumber} ${allAttempts.length}/7\n\n${emojiString}`;
+    const lastAttempt = allAttempts[allAttempts.length - 1];
+    const isWordSalad = lastAttempt.length === 4;
+    const emojiString = allAttempts
+      .map((_att, idx) => {
+        if (idx === allAttempts.length - 1) {
+          return isWordSalad ? SALAD_EMOJI : TOMATO_EMOJI;
+        }
+        return TOMATO_EMOJI;
+      })
+      .join('');
+    const numAttempts = isWordSalad ? allAttempts.length : 'X';
+    const text = `WordSalad ${saladNumber} ${numAttempts}/7\n${emojiString}`;
     try {
       await navigator.clipboard.writeText(text);
       toast(

--- a/apps/wordsalad/src/app/StatsDisplay.tsx
+++ b/apps/wordsalad/src/app/StatsDisplay.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from 'react-tooltip';
 import StatsModal from './modals/StatsModal';
 import HelpButton from './buttons/HelpButton';
 import StatsButton from './buttons/StatsButtton';
-// import RankingsModal from './modals/RankingsModal';
+import RankingsModal from './modals/RankingsModal';
 
 const DisplayContainer = styled('div', {
   display: 'flex',
@@ -68,13 +68,12 @@ const StatsDisplay: React.FC<Props> = ({
     <DisplayContainer>
       <DisplayContent>
         <RankContainer>
-          {/* <div
+          <div
             style={{ margin: '4px', cursor: 'pointer', width: '180px' }}
             onClick={() => setRankingsModalOpen(true)}
           >
             Current Rank: <span style={{ fontWeight: 'bold' }}>{ranking}</span>
-          </div> */}
-          <AttemptsDisplay attempts={attempts} />
+          </div>
           <div style={{ margin: '4px' }}>
             <StatsButton onClick={() => setStatsModalOpen(true)} />
           </div>
@@ -82,15 +81,16 @@ const StatsDisplay: React.FC<Props> = ({
             <HelpButton onClick={() => setHTPModalOpen(true)} />
           </div>
         </RankContainer>
+        <AttemptsDisplay attempts={attempts} />
       </DisplayContent>
-      {/* <RankingsModal
+      <RankingsModal
         attempts={attempts}
         ranking={ranking}
         open={rankingsModalOpen}
         isWordSalad={isWordSalad}
         isLostGame={isLostGame}
         onClose={() => setRankingsModalOpen(false)}
-      /> */}
+      />
       <StatsModal
         saladDate={saladDate}
         saladNumber={saladNumber}
@@ -120,6 +120,7 @@ const AttemptsDisplay: React.FC<AttemptsDisplayProps> = ({ attempts }) => {
     <div
       style={{
         display: 'flex',
+        margin: '0px 32px',
         justifyContent: 'space-evenly',
       }}
     >

--- a/apps/wordsalad/src/app/StatsDisplay.tsx
+++ b/apps/wordsalad/src/app/StatsDisplay.tsx
@@ -92,6 +92,7 @@ const StatsDisplay: React.FC<Props> = ({
       <StatsModal
         saladDate={saladDate}
         saladNumber={saladNumber}
+        attempts={attempts.length}
         open={statsModalOpen}
         isWordSalad={isWordSalad}
         isLostGame={isLostGame}

--- a/apps/wordsalad/src/app/StatsDisplay.tsx
+++ b/apps/wordsalad/src/app/StatsDisplay.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from 'react-tooltip';
 import StatsModal from './modals/StatsModal';
 import HelpButton from './buttons/HelpButton';
 import StatsButton from './buttons/StatsButtton';
-import RankingsModal from './modals/RankingsModal';
+// import RankingsModal from './modals/RankingsModal';
 
 const DisplayContainer = styled('div', {
   display: 'flex',
@@ -47,6 +47,7 @@ interface Props {
   setRankingsModalOpen: (bool: boolean) => void;
   setStatsModalOpen: (bool: boolean) => void;
   setHTPModalOpen: (bool: boolean) => void;
+  handleShareResults: () => Promise<void>;
 }
 
 const StatsDisplay: React.FC<Props> = ({
@@ -61,17 +62,19 @@ const StatsDisplay: React.FC<Props> = ({
   setRankingsModalOpen,
   setStatsModalOpen,
   setHTPModalOpen,
+  handleShareResults,
 }) => {
   return (
     <DisplayContainer>
       <DisplayContent>
         <RankContainer>
-          <div
+          {/* <div
             style={{ margin: '4px', cursor: 'pointer', width: '180px' }}
             onClick={() => setRankingsModalOpen(true)}
           >
             Current Rank: <span style={{ fontWeight: 'bold' }}>{ranking}</span>
-          </div>
+          </div> */}
+          <AttemptsDisplay attempts={attempts} />
           <div style={{ margin: '4px' }}>
             <StatsButton onClick={() => setStatsModalOpen(true)} />
           </div>
@@ -79,24 +82,24 @@ const StatsDisplay: React.FC<Props> = ({
             <HelpButton onClick={() => setHTPModalOpen(true)} />
           </div>
         </RankContainer>
-        <AttemptsDisplay attempts={attempts} />
       </DisplayContent>
-      <RankingsModal
+      {/* <RankingsModal
         attempts={attempts}
         ranking={ranking}
         open={rankingsModalOpen}
         isWordSalad={isWordSalad}
         isLostGame={isLostGame}
         onClose={() => setRankingsModalOpen(false)}
-      />
+      /> */}
       <StatsModal
         saladDate={saladDate}
         saladNumber={saladNumber}
-        attempts={attempts.length}
+        attempts={attempts}
         open={statsModalOpen}
         isWordSalad={isWordSalad}
         isLostGame={isLostGame}
         onClose={() => setStatsModalOpen(false)}
+        handleShareResults={handleShareResults}
       />
     </DisplayContainer>
   );
@@ -117,7 +120,6 @@ const AttemptsDisplay: React.FC<AttemptsDisplayProps> = ({ attempts }) => {
     <div
       style={{
         display: 'flex',
-        margin: '0px 32px',
         justifyContent: 'space-evenly',
       }}
     >

--- a/apps/wordsalad/src/app/buttons/ShareButton.tsx
+++ b/apps/wordsalad/src/app/buttons/ShareButton.tsx
@@ -21,27 +21,12 @@ const ButtonContent = styled('div', {
 });
 
 interface Props {
-  saladNumber: number;
-  attempts: number;
+  onClick: () => Promise<void>;
 }
 
-// TODO - display toast
-const handleCopyResults = async (saladNumber: number, attempts: number) => {
-  const text = `WordSalad ${saladNumber} ${attempts}/7`;
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (error) {
-    const message =
-      error && typeof error === 'object' && 'message' in error
-        ? error.message
-        : null;
-    console.error(message);
-  }
-};
-
 // renders a stylized restart button
-const ShareButton: React.FC<Props> = ({ saladNumber, attempts }) => (
-  <StyledButton onClick={() => handleCopyResults(saladNumber, attempts)}>
+const ShareButton: React.FC<Props> = ({ onClick }) => (
+  <StyledButton onClick={onClick}>
     <ButtonContent>
       <div style={{ marginRight: '8px' }}>Share</div>
       <ShareIcon />

--- a/apps/wordsalad/src/app/buttons/ShareButton.tsx
+++ b/apps/wordsalad/src/app/buttons/ShareButton.tsx
@@ -21,12 +21,27 @@ const ButtonContent = styled('div', {
 });
 
 interface Props {
-  onClick: () => void;
+  saladNumber: number;
+  attempts: number;
 }
 
+// TODO - display toast
+const handleCopyResults = async (saladNumber: number, attempts: number) => {
+  const text = `WordSalad ${saladNumber} ${attempts}/7`;
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (error) {
+    const message =
+      error && typeof error === 'object' && 'message' in error
+        ? error.message
+        : null;
+    console.error(message);
+  }
+};
+
 // renders a stylized restart button
-const ShareButton: React.FC<Props> = ({ onClick }) => (
-  <StyledButton onClick={onClick}>
+const ShareButton: React.FC<Props> = ({ saladNumber, attempts }) => (
+  <StyledButton onClick={() => handleCopyResults(saladNumber, attempts)}>
     <ButtonContent>
       <div style={{ marginRight: '8px' }}>Share</div>
       <ShareIcon />

--- a/apps/wordsalad/src/app/buttons/ShareButton.tsx
+++ b/apps/wordsalad/src/app/buttons/ShareButton.tsx
@@ -2,32 +2,35 @@ import { styled } from '@stitches/react';
 
 const StyledButton = styled('button', {
   border: 'none',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
   backgroundColor: '#217C7E',
   '&:hover': {
     opacity: 0.75,
     cursor: 'pointer',
   },
-  margin: '4px 0px',
+  margin: '16px',
+  borderRadius: '30px',
+});
+
+const ButtonContent = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  margin: '8px 24px',
+  color: 'white',
+  fontSize: 'large',
 });
 
 interface Props {
-  disabled: boolean;
   onClick: () => void;
 }
 
 // renders a stylized restart button
-const ShareButton: React.FC<Props> = ({ disabled, onClick }) => (
-  <StyledButton
-    onClick={onClick}
-    disabled={disabled}
-    style={{
-      ...(disabled ? { opacity: 0.5, cursor: 'not-allowed' } : null),
-    }}
-  >
-    <ShareIcon />
+const ShareButton: React.FC<Props> = ({ onClick }) => (
+  <StyledButton onClick={onClick}>
+    <ButtonContent>
+      <div style={{ marginRight: '8px' }}>Share</div>
+      <ShareIcon />
+    </ButtonContent>
   </StyledButton>
 );
 
@@ -38,8 +41,8 @@ const ShareIcon = () => (
     height={28}
     viewBox="0 0 24 24"
     fill="none"
-    stroke="#9A3334"
-    strokeWidth="2"
+    stroke="white"
+    strokeWidth="1"
     strokeLinecap="round"
     strokeLinejoin="round"
   >

--- a/apps/wordsalad/src/app/buttons/ShareButton.tsx
+++ b/apps/wordsalad/src/app/buttons/ShareButton.tsx
@@ -1,0 +1,54 @@
+import { styled } from '@stitches/react';
+
+const StyledButton = styled('button', {
+  border: 'none',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  backgroundColor: '#217C7E',
+  '&:hover': {
+    opacity: 0.75,
+    cursor: 'pointer',
+  },
+  margin: '4px 0px',
+});
+
+interface Props {
+  disabled: boolean;
+  onClick: () => void;
+}
+
+// renders a stylized restart button
+const ShareButton: React.FC<Props> = ({ disabled, onClick }) => (
+  <StyledButton
+    onClick={onClick}
+    disabled={disabled}
+    style={{
+      ...(disabled ? { opacity: 0.5, cursor: 'not-allowed' } : null),
+    }}
+  >
+    <ShareIcon />
+  </StyledButton>
+);
+
+const ShareIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={28}
+    height={28}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="#9A3334"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="18" cy="5" r="3"></circle>
+    <circle cx="6" cy="12" r="3"></circle>
+    <circle cx="18" cy="19" r="3"></circle>
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+  </svg>
+);
+
+export default ShareButton;

--- a/apps/wordsalad/src/app/modals/StatsModal.tsx
+++ b/apps/wordsalad/src/app/modals/StatsModal.tsx
@@ -100,11 +100,12 @@ export type SaladData = Pick<DailySalad, 'date' | 'saladNumber'>;
 interface Props {
   saladDate: string;
   saladNumber: number;
-  attempts: number;
+  attempts: string[][];
   open: boolean;
   isWordSalad: boolean;
   isLostGame: boolean;
   onClose: () => void;
+  handleShareResults: () => Promise<void>;
 }
 
 const getSuffix = (lastDigit: string) => {
@@ -158,6 +159,7 @@ const StatsModal: React.FC<Props> = ({
   isLostGame,
   isWordSalad,
   onClose,
+  handleShareResults,
 }) => {
   const { storedStats: userStats } = retrieveLSData(saladNumber);
   const { played, gamesWon, currentStreak, maxStreak } = userStats;
@@ -245,7 +247,7 @@ const StatsModal: React.FC<Props> = ({
           <div>Max Streak</div>
         </ModalContent>
       </ModalContentWrapper>
-      <ShareButton saladNumber={saladNumber} attempts={attempts} />
+      <ShareButton onClick={handleShareResults} />
     </Modal>
   );
 };

--- a/apps/wordsalad/src/app/modals/StatsModal.tsx
+++ b/apps/wordsalad/src/app/modals/StatsModal.tsx
@@ -3,6 +3,7 @@ import 'react-responsive-modal/styles.css';
 import { Modal } from 'react-responsive-modal';
 import { retrieveLSData } from '../GameLayer';
 import { DailySalad } from '../app';
+import ShareButton from '../buttons/ShareButton';
 
 const ModalHeader = styled('h3', {
   display: 'flex',
@@ -242,6 +243,7 @@ const StatsModal: React.FC<Props> = ({
           <div>Max Streak</div>
         </ModalContent>
       </ModalContentWrapper>
+      <ShareButton onClick={() => null} />
     </Modal>
   );
 };

--- a/apps/wordsalad/src/app/modals/StatsModal.tsx
+++ b/apps/wordsalad/src/app/modals/StatsModal.tsx
@@ -100,6 +100,7 @@ export type SaladData = Pick<DailySalad, 'date' | 'saladNumber'>;
 interface Props {
   saladDate: string;
   saladNumber: number;
+  attempts: number;
   open: boolean;
   isWordSalad: boolean;
   isLostGame: boolean;
@@ -152,6 +153,7 @@ const formatDate = (date: string) => {
 const StatsModal: React.FC<Props> = ({
   saladDate,
   saladNumber,
+  attempts,
   open,
   isLostGame,
   isWordSalad,
@@ -243,7 +245,7 @@ const StatsModal: React.FC<Props> = ({
           <div>Max Streak</div>
         </ModalContent>
       </ModalContentWrapper>
-      <ShareButton onClick={() => null} />
+      <ShareButton saladNumber={saladNumber} attempts={attempts} />
     </Modal>
   );
 };


### PR DESCRIPTION
This pr adds a `Share` button to the`StatsModal`, which copies the results of a user's game to the clipboard, so they can share it on social media. It also removes the rankings concept to simplify gameplay for the time being