### PR TITLE
feat(api): use railway internal host

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -11,7 +11,7 @@ type AppConfig = {
   maxPoolSize: number;
   allowedOrigins: string[];
   port: number;
-  apiUrl: string;
+  railwayInternalHost: string;
 };
 
 const env = envalid.cleanEnv(process.env, {
@@ -23,7 +23,7 @@ const env = envalid.cleanEnv(process.env, {
   MIN_POOL_SIZE: num({ default: 1 }),
   MAX_POOL_SIZE: num({ default: 20 }),
   PORT: num({ default: 8001 }),
-  API_URL: str(),
+  RAILWAY_INTERNAL_HOST: str(),
 });
 
 const config: AppConfig = {
@@ -36,7 +36,7 @@ const config: AppConfig = {
   maxPoolSize: env.MAX_POOL_SIZE,
   allowedOrigins: env.ALLOWED_ORIGINS.split(','),
   port: env.PORT,
-  apiUrl: env.API_URL,
+  railwayInternalHost: env.RAILWAY_INTERNAL_HOST,
 };
 
 export default config;

--- a/apps/api/src/cron-job.ts
+++ b/apps/api/src/cron-job.ts
@@ -2,6 +2,9 @@ import cron from 'node-cron';
 import axios from 'axios';
 import config from './config';
 
+const host = config.railwayInternalHost ?? 'localhost';
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+
 const SCHEDULE = '* 0 * * 0-6';
 
 export const scheduleCronAndLogs = () => {
@@ -15,7 +18,7 @@ export const scheduleCronAndLogs = () => {
     SCHEDULE,
     () => {
       axios
-        .post(`${config.apiUrl}/generate-salad`)
+        .post(`http://${host}:${port}/generate-salad`)
         .then((response) => {
           console.log('GENERATED SALAD:', response?.data?.initialWord);
         })


### PR DESCRIPTION
Quick pr to use the railway private network address when running the `generate-salad` cron job