### PR TITLE
fix: use rel link for favicon

### DIFF
--- a/apps/wordsalad/index.html
+++ b/apps/wordsalad/index.html
@@ -6,7 +6,7 @@
     <base href="/" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="./favicon.ico" />
     <link rel="stylesheet" href="/src/styles.css" />
   </head>
   <body>


### PR DESCRIPTION
Quick pr to use a relative link to the `favicon` for the app