### PR TITLE
fix(cron-job): run job on minute 1

### DIFF
--- a/apps/api/src/cron-job.ts
+++ b/apps/api/src/cron-job.ts
@@ -2,7 +2,7 @@ import cron from 'node-cron';
 import axios from 'axios';
 import config from './config';
 
-const SCHEDULE = '* 3 * * 0-6';
+const SCHEDULE = '1 3 * * 0-6';
 
 export const scheduleCronAndLogs = () => {
   const isValid = cron.validate(SCHEDULE);


### PR DESCRIPTION
Quick pr to run the `generate-salad` function once during that hour, instead of every minute